### PR TITLE
Disable scecure screen content on Android Q+

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -7,6 +7,7 @@ import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.media.MediaFormat;
+import android.os.Build;
 import android.os.IBinder;
 import android.view.Surface;
 
@@ -225,7 +226,7 @@ public class ScreenEncoder implements Device.RotationListener {
     }
 
     private static IBinder createDisplay() {
-        return SurfaceControl.createDisplay("scrcpy", true);
+        return SurfaceControl.createDisplay("scrcpy", Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q);
     }
 
     private static void configure(MediaCodec codec, MediaFormat format) {


### PR DESCRIPTION
Using `createDisplay(name, secure)` with `secure == true` goes against the security recommendations and posses risk for leaking sensitive user/app data. 

Starting on Android 12 this policy will be enforced and the call will crash for all non-secure displays with the following output:
```
[server] ERROR: Exception on thread Thread[main,5,main]
java.lang.AssertionError: java.lang.reflect.InvocationTargetException
	at com.genymobile.scrcpy.wrappers.SurfaceControl.setDisplaySurface(SurfaceControl.java:75)
	at com.genymobile.scrcpy.ScreenEncoder.setDisplaySurface(ScreenEncoder.java:243)
	at com.genymobile.scrcpy.ScreenEncoder.internalStreamScreen(ScreenEncoder.java:91)
	at com.genymobile.scrcpy.ScreenEncoder.streamScreen(ScreenEncoder.java:60)
	at com.genymobile.scrcpy.Server.scrcpy(Server.java:80)
	at com.genymobile.scrcpy.Server.main(Server.java:252)
	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:355)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at com.genymobile.scrcpy.wrappers.SurfaceControl.setDisplaySurface(SurfaceControl.java:73)
	... 7 more
Caused by: java.lang.IllegalArgumentException: displayToken must not be null
	at android.view.SurfaceControl$Transaction.setDisplaySurface(SurfaceControl.java:3111)
	at android.view.SurfaceControl.setDisplaySurface(SurfaceControl.java:2194)
	... 9 more
```

To prevent Scrcpy from crashing and to protect sensitive app data, this change is suggested for apps running Android Q and higher.